### PR TITLE
runtime: add support for setting frames on log ports

### DIFF
--- a/rock/runtime.rb
+++ b/rock/runtime.rb
@@ -274,11 +274,13 @@ module Orocos
         @transformer ||= ::Transformer::RuntimeSetup.new
     end
 
-    class InputPort
+    class Port
         include ::Transformer::PortExtension
     end
 
-    class OutputPort
-        include ::Transformer::PortExtension
+    module Log
+        class OutputPort
+            include ::Transformer::PortExtension
+        end
     end
 end


### PR DESCRIPTION
This fixes using the transformer setup helpers in log replay scripts when associated with https://github.com/rock-core/tools-orocosrb/pull/35  
