### PR TITLE
Helper methods for C++ Tooling

### DIFF
--- a/BroadcastTypes.hpp
+++ b/BroadcastTypes.hpp
@@ -6,6 +6,13 @@
 #include <vector>
 
 namespace transformer {
+    
+    struct TransformationDescription
+    {
+        std::string sourceFrame;
+        std::string targetFrame;
+    };
+    
     struct PortFrameAssociation
     {
         std::string task;

--- a/rock/orogen_plugin.rb
+++ b/rock/orogen_plugin.rb
@@ -714,6 +714,26 @@ module TransformerPlugin
                 task.input_port('dynamic_transformations', '/base/samples/RigidBodyState').
                     multiplexes.
                     needs_reliable_connection
+                    
+                #add method to request needed transformations
+                transformationBody = "
+    std::vector<base::samples::RigidBodyState > ret;
+    const std::vector<transformer::Transformation *> &transformations(_transformer.getRegisteredTransformations());
+    ret.reserve(transformations.size());
+    
+    for(std::vector<transformer::Transformation *>::const_iterator transform = transformations.begin();
+        transform != transformations.end(); transform++)
+    {
+        base::samples::RigidBodyState curTr;
+        curTr.sourceFrame = (*transform)->getSourceFrame();
+        curTr.targetFrame = (*transform)->getTargetFrame();
+        
+        ret.push_back(curTr);
+    }
+    
+    return ret;"
+                task.hidden_operation("getNeededTransformations", transformationBody).
+                    returns('std::vector<base::samples::RigidBodyState>')
             end
                 
             # Add period property for every data stream

--- a/rock/orogen_plugin.rb
+++ b/rock/orogen_plugin.rb
@@ -53,7 +53,7 @@ module TransformerPlugin
         end
 
 	def generate(task, config)
-            task.project.using_library('transformer', :typekit => false)
+            task.project.using_library('transformer', :typekit => true)
             port_listener_ext = task.extension("port_listener", false)
 
             if !(tr = config.task.superclass.find_extension('transformer')) || !tr.needs_transformer?
@@ -740,14 +740,14 @@ module TransformerPlugin
             end.compact
             #add method to request needed transformations
             transformationBody = frame_selection.join("\n") + " \n
-    std::vector<base::samples::RigidBodyState > ret;
+    std::vector<transformer::TransformationDescription > ret;
     const std::vector<transformer::Transformation *> &transformations(_transformer.getRegisteredTransformations());
     ret.reserve(transformations.size());
     
     for(std::vector<transformer::Transformation *>::const_iterator transform = transformations.begin();
         transform != transformations.end(); transform++)
     {
-        base::samples::RigidBodyState curTr;
+        transformer::TransformationDescription curTr;
         curTr.sourceFrame = (*transform)->getSourceFrame();
         curTr.targetFrame = (*transform)->getTargetFrame();
         
@@ -757,7 +757,7 @@ module TransformerPlugin
     return ret;"
 
             task.hidden_operation("getNeededTransformations", transformationBody).
-                returns('std::vector<base::samples::RigidBodyState>')
+                returns('std::vector<transformer::TransformationDescription>')
 
         end
 

--- a/rock/orogen_plugin.rb
+++ b/rock/orogen_plugin.rb
@@ -734,12 +734,18 @@ module TransformerPlugin
                 end
             end
             
+            task.hidden_operation("getNeededTransformations").
+                returns('std::vector<transformer::TransformationDescription>')
+
+        end
+        
+        def get_transform_code
             #also do frame mapping in case the transformations are requested
             frame_selection = configurable_frames.sort.map do |frame_name|
                 "    _#{name}.setFrameMapping(\"#{frame_name}\", _#{frame_name}_frame);"
             end.compact
             #add method to request needed transformations
-            transformationBody = frame_selection.join("\n") + " \n
+            frame_selection.join("\n") + " \n
     std::vector<transformer::TransformationDescription > ret;
     const std::vector<transformer::Transformation *> &transformations(_transformer.getRegisteredTransformations());
     ret.reserve(transformations.size());
@@ -755,10 +761,6 @@ module TransformerPlugin
     }
     
     return ret;"
-
-            task.hidden_operation("getNeededTransformations", transformationBody).
-                returns('std::vector<transformer::TransformationDescription>')
-
         end
 
         # Lists the frames for which a configuration interface should be
@@ -801,12 +803,22 @@ module TransformerPlugin
         def needs_transformer?
             !needed_transformations.empty? || !streams.empty? || supercall(nil, :needs_transformer?)
         end
+        
+        
+        # Called by the oroGen C++ code generator to add code objects to the
+        # task implementation
+        def early_register_for_generation(task)
+            if needs_transformer?
+                task.operation('get_transform_code').
+                    base_body(get_transform_code)
+            end
+        end
 
         # Called by the oroGen C++ code generator to add code objects to the
         # task implementation
         def generation_hook(task)
             if needs_transformer?
-                Generator.new.generate(task, self)
+                gen.generate(task, self)
             end
         end
 

--- a/rock/orogen_plugin.rb
+++ b/rock/orogen_plugin.rb
@@ -732,11 +732,7 @@ module TransformerPlugin
                     task.property("#{name}_frame", "/std/string", name).
                         doc("the global name that should be used for the internal #{name} frame")
                 end
-            end
-            
-            task.hidden_operation("getNeededTransformations").
-                returns('std::vector<transformer::TransformationDescription>')
-
+            end            
         end
         
         def get_transform_code
@@ -809,8 +805,9 @@ module TransformerPlugin
         # task implementation
         def early_register_for_generation(task)
             if needs_transformer?
-                task.operation('get_transform_code').
-                    base_body(get_transform_code)
+                task.hidden_operation("getNeededTransformations").
+                    base_body(get_transform_code).
+                    returns('std::vector<transformer::TransformationDescription>')
             end
         end
 
@@ -818,7 +815,7 @@ module TransformerPlugin
         # task implementation
         def generation_hook(task)
             if needs_transformer?
-                gen.generate(task, self)
+                Generator.new.generate(task, self)
             end
         end
 

--- a/rock/runtime.rb
+++ b/rock/runtime.rb
@@ -204,9 +204,9 @@ module Transformer
             # rest.
             manager.conf.each_dynamic_transform do |dyn|
                 begin
-                    producer_port = resolve_producer(dyn)
+                    producer_name, producer_port_name = dyn.producer.split('.')
                     configuration_state.port_transformation_associations <<
-                        Types::Transformer::PortTransformationAssociation.new(:task => producer_port.task.name, :port => producer_port.name,
+                        Types::Transformer::PortTransformationAssociation.new(:task => producer_name, :port => producer_port_name,
                                                                          :from_frame => dyn.from, :to_frame => dyn.to)
                 rescue Orocos::NotFound
                 end

--- a/transformer.orogen
+++ b/transformer.orogen
@@ -9,6 +9,8 @@ typekit do
     # adding a new package just for that
     export_types '/std/vector</base/samples/RigidBodyState>'
     export_types '/transformer/TransformerStatus'
+    export_types '/transformer/TransformationDescription'
+    export_types '/std/vector</transformer/TransformationDescription>'
 end	
 
 # Task that allows to broadcast transformer information, mostly used for GUI


### PR DESCRIPTION
The C++ tooling relies on this helper method to
configure the transformer stack. In general it has 
nice properties and might also be useful for the
ruby tooling.
