### PR TITLE
Add using_library to avoid problems with missing headers in orogen

### DIFF
--- a/transformer.orogen
+++ b/transformer.orogen
@@ -1,5 +1,6 @@
 name "transformer"
 
+using_library "transformer"
 import_types_from "base"
 import_types_from "BroadcastTypes.hpp"
 import_types_from "transformer/TransformationStatus.hpp"


### PR DESCRIPTION
Without using_library the packageconfig-file is not parsed and transformationStatus.hpp was only found because it's in the default-path by luck in a standard-rock-installation.
