### PR TITLE
Configurable transformer_boradcaster

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -35,12 +35,13 @@ void Task::setConfiguration(::transformer::ConfigurationState const& configurati
 //         return false;
 //     return true;
 // }
-// bool Task::startHook()
-// {
-//     if (! TaskBase::startHook())
-//         return false;
-//     return true;
-// }
+bool Task::startHook()
+{
+     if (! TaskBase::startHook())
+         return false;
+     setConfiguration(_configuration.get());
+     return true;
+}
 // void Task::updateHook()
 // {
 //     TaskBase::updateHook();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -69,7 +69,7 @@ namespace transformer {
          * stay in Stopped. Otherwise, it goes into Running and updateHook()
          * will be called.
          */
-        // bool startHook();
+        bool startHook();
 
         /** This hook is called by Orocos when the component is in the Running
          * state, at each activity step. Here, the activity gives the "ticks"

--- a/transformer.orogen
+++ b/transformer.orogen
@@ -17,6 +17,8 @@ task_context "Task" do
     operation('setConfiguration').
         arg("configuration", "transformer/ConfigurationState")
 
+    property "configuration", "transformer/ConfigurationState"
+
     # Outputs a snapshot of all the port-to-frame associations declared at a
     # certain point in time. The port is declared so that
     #


### PR DESCRIPTION
Let transformer::Task (broadcaster) publish a ConfigurationState specified as property. The configured property will be published in startHook  of component.

Using the service-calls to set the ConfigurationState still works with no difference.