### PR TITLE
Fix typo in variable name introduced in commit 1080ec5

### DIFF
--- a/rock/runtime.rb
+++ b/rock/runtime.rb
@@ -207,7 +207,7 @@ module Transformer
                     producer_name, producer_port_name = dyn.producer.split('.')
                     configuration_state.port_transformation_associations <<
                         Types.transformer.PortTransformationAssociation.new(task: producer_name,
-                                                                            port: producer_port.name,
+                                                                            port: producer_port_name,
                                                                             from_frame: dyn.from,
                                                                             to_frame: dyn.to)
                 rescue Orocos::NotFound


### PR DESCRIPTION
Currently a NameError is thrown, stating that the variable producer_port is unknown. This error is packaged in the rock master-20.06 release!

The error was introduced [here](https://github.com/rock-core/drivers-orogen-transformer/commit/1080ec59e23e790a94bd9d397b5f8e380a8dab9f#diff-f114f7f3eaa98db7b5e434fcfdda5bf0R209).